### PR TITLE
feat: 상품 서비스 레이어 도입 및 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/bootcamp/paymentproject/common/config/SecurityConfig.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/config/SecurityConfig.java
@@ -75,7 +75,8 @@ public class SecurityConfig {
 
                     // 3) 공개 API
                     .requestMatchers(HttpMethod.GET, "/api/public/**").permitAll()
-
+                    .requestMatchers(HttpMethod.GET, "/api/points/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
                     // 4) 인증 API
                     .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/signup").permitAll()
 

--- a/src/main/java/com/bootcamp/paymentproject/product/controller/ProductController.java
+++ b/src/main/java/com/bootcamp/paymentproject/product/controller/ProductController.java
@@ -1,8 +1,9 @@
 package com.bootcamp.paymentproject.product.controller;
 
 import com.bootcamp.paymentproject.common.dto.SuccessResponse;
+import com.bootcamp.paymentproject.product.dto.response.ProductResponse;
 import com.bootcamp.paymentproject.product.entity.Product;
-import com.bootcamp.paymentproject.product.service.ProductService; // Service 임포트
+import com.bootcamp.paymentproject.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,17 +15,23 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductController {
 
-    private final ProductService productService; // repository 대신 service의존
+    private final ProductService productService;
 
     @GetMapping
-    public ResponseEntity<SuccessResponse<List<Product>>> getAllProducts() {
-        List<Product> products = productService.getAllProducts();
-        return ResponseEntity.ok(SuccessResponse.success(products, "상품 목록 조회가 완료되었습니다."));
+    public ResponseEntity<SuccessResponse<List<ProductResponse>>> getAllProducts() {
+        List<ProductResponse> responses = productService.getAllProducts()
+                .stream()
+                .map(ProductResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(SuccessResponse.success(responses, "상품 목록 조회가 완료되었습니다."));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<SuccessResponse<Product>> getProductById(@PathVariable Long id) {
+    public ResponseEntity<SuccessResponse<ProductResponse>> getProductById(@PathVariable Long id) {
         Product product = productService.getProductById(id);
-        return ResponseEntity.ok(SuccessResponse.success(product, "상품 상세 조회가 완료되었습니다."));
+        ProductResponse response = ProductResponse.from(product);
+
+        return ResponseEntity.ok(SuccessResponse.success(response, "상품 상세 조회가 완료되었습니다."));
     }
 }

--- a/src/main/java/com/bootcamp/paymentproject/product/controller/ProductController.java
+++ b/src/main/java/com/bootcamp/paymentproject/product/controller/ProductController.java
@@ -1,14 +1,11 @@
 package com.bootcamp.paymentproject.product.controller;
 
-import com.bootcamp.paymentproject.common.dto.SuccessResponse; // 👈 방금 만든 DTO 임포트
+import com.bootcamp.paymentproject.common.dto.SuccessResponse;
 import com.bootcamp.paymentproject.product.entity.Product;
-import com.bootcamp.paymentproject.product.repository.ProductRepository;
+import com.bootcamp.paymentproject.product.service.ProductService; // Service 임포트
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,14 +14,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductController {
 
-    private final ProductRepository productRepository;
+    private final ProductService productService; // repository 대신 service의존
 
     @GetMapping
     public ResponseEntity<SuccessResponse<List<Product>>> getAllProducts() {
-        // 1. DB에서 상품 목록을 가져옵니다.
-        List<Product> products = productRepository.findAll();
+        List<Product> products = productService.getAllProducts();
+        return ResponseEntity.ok(SuccessResponse.success(products, "상품 목록 조회가 완료되었습니다."));
+    }
 
-        // 2. 그냥 보내지 말고 ApiResponse.success() 봉투에 담아서 보냅니다.
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.success(products,"주문이 성공적으로 조회했습니다"));
+    @GetMapping("/{id}")
+    public ResponseEntity<SuccessResponse<Product>> getProductById(@PathVariable Long id) {
+        Product product = productService.getProductById(id);
+        return ResponseEntity.ok(SuccessResponse.success(product, "상품 상세 조회가 완료되었습니다."));
     }
 }

--- a/src/main/java/com/bootcamp/paymentproject/product/dto/ProductResponse.java
+++ b/src/main/java/com/bootcamp/paymentproject/product/dto/ProductResponse.java
@@ -1,0 +1,4 @@
+package com.bootcamp.paymentproject.product.dto;
+
+public class ProductResponse {
+}

--- a/src/main/java/com/bootcamp/paymentproject/product/repository/ProductRepository.java
+++ b/src/main/java/com/bootcamp/paymentproject/product/repository/ProductRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, String> {
+public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/com/bootcamp/paymentproject/product/service/ProductService.java
+++ b/src/main/java/com/bootcamp/paymentproject/product/service/ProductService.java
@@ -1,0 +1,34 @@
+package com.bootcamp.paymentproject.product.service;
+
+import com.bootcamp.paymentproject.product.entity.Product;
+import com.bootcamp.paymentproject.product.exception.ProductErrorCode;
+import com.bootcamp.paymentproject.product.exception.ProductException;
+import com.bootcamp.paymentproject.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 읽기 전용 성능 최적화
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    /**
+     * 전체 상품 목록 조회
+     */
+    public List<Product> getAllProducts() {
+        return productRepository.findAll();
+    }
+
+    /**
+     * 단건 상품 조회
+     */
+    public Product getProductById(Long id) {
+        return productRepository.findById(id)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
상품 서비스 레이어(ProductService) 도입: 비즈니스 로직 분리를 통한 유지보수성 향상

상품 상세 조회 API 구현: GET /api/products/{id} 엔드포인트 추가

Repository 타입 안정성 확보: ProductRepository의 ID 타입을 Long으로 수정하여 엔티티와 동기화

공통 응답 규격 적용: 모든 상품 API에 SuccessResponse 봉투 패턴 적용

## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
[x] 브랜치 이름 규칙을 준수했나요? (예: feat/product)

[x] 코딩 컨벤션을 준수했나요?

[x] 기능에 대한 테스트를 수행했나요? (Postman 테스트 완료)

[x] 불필요한 주석이나 로그(console.log)를 제거했나요?
## 💬 기타 사항
상품전체조회
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/d0a0e257-f78c-44b9-a0e0-cc849db19fe7" />


상품단건조회
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/e92b938b-3de3-4add-905a-dbe3357fa974" />

