### PR TITLE
feat: paymentId로 PortOne 결제 조회 구현

### DIFF
--- a/src/main/java/com/bootcamp/paymentproject/common/config/HttpClientConfig.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/config/HttpClientConfig.java
@@ -1,0 +1,14 @@
+package com.bootcamp.paymentproject.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/bootcamp/paymentproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/exception/ErrorCode.java
@@ -7,7 +7,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    PAYMENT_NOT_FOUND("PAYMENT_NOT_FOUND", "존재하지 않는 결제 정보 입니다.", HttpStatus.NOT_FOUND);
+    PAYMENT_NOT_FOUND("PAYMENT_NOT_FOUND", "존재하지 않는 결제 정보 입니다.", HttpStatus.NOT_FOUND),
+
+    // PortOne (TODO 2)
+    PORTONE_UNAUTHORIZED("PORTONE_UNAUTHORIZED", "PortOne 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    PORTONE_PAYMENT_NOT_FOUND("PORTONE_PAYMENT_NOT_FOUND", "PortOne에서 결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PORTONE_API_ERROR("PORTONE_API_ERROR", "PortOne API 호출 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
+    PORTONE_RESPONSE_NULL("PORTONE_RESPONSE_NULL", "PortOne 응답이 비어있습니다.", HttpStatus.BAD_GATEWAY);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/bootcamp/paymentproject/common/exception/ServiceException.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/exception/ServiceException.java
@@ -14,4 +14,9 @@ public class ServiceException extends RuntimeException {
     public ServiceException(String code, String message, HttpStatus status, ErrorCode errorCode) {
         this.errorCode = errorCode;
     }
+
+    public ServiceException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/bootcamp/paymentproject/webhook/client/PortOneClient.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/client/PortOneClient.java
@@ -1,0 +1,7 @@
+package com.bootcamp.paymentproject.webhook.client;
+
+import com.bootcamp.paymentproject.webhook.dto.PortonePaymentResponse;
+
+public interface PortOneClient {
+    PortonePaymentResponse getPayment(String paymentId);
+}

--- a/src/main/java/com/bootcamp/paymentproject/webhook/client/PortoneClientImpl.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/client/PortoneClientImpl.java
@@ -1,0 +1,76 @@
+package com.bootcamp.paymentproject.webhook.client;
+
+import com.bootcamp.paymentproject.common.exception.ErrorCode;
+import com.bootcamp.paymentproject.common.exception.ServiceException;
+import com.bootcamp.paymentproject.webhook.dto.PortonePaymentResponse;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class PortoneClientImpl implements PortOneClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${portone.api.base-url:https://api.portone.io}")
+    private String baseUrl;
+
+    @Value("${portone.api.secret:}")
+    private String apiSecret;
+
+    @Override
+    public PortonePaymentResponse getPayment(String paymentId) {
+
+        // 결제 조회 API URL 생성
+        String url = baseUrl + "/payments/" + paymentId;
+
+        // Authorization 헤더 설정 (Bearer Token 방식)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "PortOne " + apiSecret);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        try {
+            // PortOne 결제 조회 요청 (SSOT)
+            ResponseEntity<PortonePaymentResponse> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    PortonePaymentResponse.class
+            );
+
+            // 응답 body 추출 및 null 체크
+            PortonePaymentResponse body = response.getBody();
+            if (body == null) {
+                // 응답이 비어있는 경우 → 시스템 예외로 변환
+                throw new ServiceException(ErrorCode.PORTONE_RESPONSE_NULL);
+            }
+
+            return body;
+
+        } catch (HttpClientErrorException.Unauthorized e) {
+            // 401 Unauthorized → 인증 실패
+            throw new ServiceException(ErrorCode.PORTONE_UNAUTHORIZED, e);
+
+        } catch (HttpClientErrorException.NotFound e) {
+            // 404 Not Found → 해당 paymentId 없음
+            throw new ServiceException(ErrorCode.PORTONE_PAYMENT_NOT_FOUND, e);
+
+        } catch (HttpClientErrorException e) {
+            // 기타 4xx 에러 → PortOne API 요청 오류
+            throw new ServiceException(ErrorCode.PORTONE_API_ERROR, e);
+
+        } catch (Exception e) {
+            // 네트워크 오류, JSON 파싱 오류 등 예상 못한 예외
+            throw new ServiceException(ErrorCode.PORTONE_API_ERROR, e);
+        }
+    }
+}

--- a/src/main/java/com/bootcamp/paymentproject/webhook/client/PortoneClientImpl.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/client/PortoneClientImpl.java
@@ -32,7 +32,7 @@ public class PortoneClientImpl implements PortOneClient {
         // 결제 조회 API URL 생성
         String url = baseUrl + "/payments/" + paymentId;
 
-        // Authorization 헤더 설정 (Bearer Token 방식)
+        // Authorization 헤더 설정 (PortOne 전용 방식)
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "PortOne " + apiSecret);
 

--- a/src/main/java/com/bootcamp/paymentproject/webhook/client/PortoneClientImpl.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/client/PortoneClientImpl.java
@@ -3,7 +3,6 @@ package com.bootcamp.paymentproject.webhook.client;
 import com.bootcamp.paymentproject.common.exception.ErrorCode;
 import com.bootcamp.paymentproject.common.exception.ServiceException;
 import com.bootcamp.paymentproject.webhook.dto.PortonePaymentResponse;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;

--- a/src/main/java/com/bootcamp/paymentproject/webhook/controller/WebhookController.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/controller/WebhookController.java
@@ -7,7 +7,6 @@ import com.bootcamp.paymentproject.webhook.service.WebhookService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,7 +52,7 @@ public class WebhookController {
         // 검증 실패 시 종료
         if (!verified) {
             log.warn("[PORTONE_WEBHOOK] signature verification failed");
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.ok(SuccessResponse.success(null, "ignored"));
         }
 
         // 4. 검증 통과 후 DTO 변환
@@ -61,7 +60,7 @@ public class WebhookController {
         try {
             payload = objectMapper.readValue(rawBody, PortoneWebhookPayload.class);
         } catch (Exception e) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.ok(SuccessResponse.success(null, "ignored"));
         }
 
         // 5. 이후부터는 “신뢰 가능한 데이터”

--- a/src/main/java/com/bootcamp/paymentproject/webhook/dto/PortonePaymentResponse.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/dto/PortonePaymentResponse.java
@@ -1,0 +1,21 @@
+package com.bootcamp.paymentproject.webhook.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+public class PortonePaymentResponse {
+
+    private String paymentId;
+    private String status;
+    private Amount amount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Amount {
+        private BigDecimal total;
+    }
+}

--- a/src/main/java/com/bootcamp/paymentproject/webhook/service/WebhookService.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/service/WebhookService.java
@@ -2,6 +2,8 @@ package com.bootcamp.paymentproject.webhook.service;
 
 import com.bootcamp.paymentproject.common.exception.ErrorCode;
 import com.bootcamp.paymentproject.common.exception.ServiceException;
+import com.bootcamp.paymentproject.order.Repository.OrderRepository;
+import com.bootcamp.paymentproject.payment.repository.PaymentRepository;
 import com.bootcamp.paymentproject.webhook.client.PortOneClient;
 import com.bootcamp.paymentproject.webhook.dto.PortonePaymentResponse;
 import com.bootcamp.paymentproject.webhook.dto.PortoneWebhookPayload;
@@ -21,6 +23,9 @@ public class WebhookService {
     private final WebhookEventRepository webhookEventRepository;
     private final PortOneClient portOneClient;
 
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+
     /**
      * PortOne webhook 처리 흐름
      * 1) webhookId 멱등 처리
@@ -29,10 +34,30 @@ public class WebhookService {
      * 4) 결제/주문 상태 반영
      * 5) webhook_event 처리 결과 기록(PROCESSED/FAILED)
      */
-    @Transactional
     public void handleVerifiedWebhook(String webhookId,                    // 중복인지 확인
                                       String webhookTimestamp,             // 유효한 요청인지 확인
                                       PortoneWebhookPayload payload) {     // 실제 결제 처리
+
+        // TODO 2) PortOne 결제 조회(SSOT)
+        String paymentId = payload.getData().getPaymentId();
+
+        PortonePaymentResponse result = portOneClient.getPayment(paymentId);
+        if (result == null) {
+            throw new ServiceException(ErrorCode.PORTONE_RESPONSE_NULL);
+        }
+
+        log.info("[PORTONE_PAYMENT] paymentId={}, status={}, amount={}",
+                result.getPaymentId(), result.getStatus(), result.getAmount());
+
+        // 외부 API 조회가 끝난 다음에, DB 반영 로직만 트랜잭션으로 처리
+        handleAfterFetch(webhookId, webhookTimestamp, payload, result);
+    }
+
+    @Transactional
+    public void handleAfterFetch(String webhookId,                    // 중복인지 확인
+                                      String webhookTimestamp,             // 유효한 요청인지 확인
+                                      PortoneWebhookPayload payload,       // 실제 결제 처리
+                                      PortonePaymentResponse result) {
 
         // TODO 1) 멱등: 이미 처리된 webhookId면 종료
         if (webhookEventRepository.findByWebhookId(webhookId).isPresent()) {
@@ -57,17 +82,6 @@ public class WebhookService {
         }
 
         try {
-            // TODO 2) PortOne 결제 조회(SSOT)
-            String paymentId = payload.getData().getPaymentId();
-
-            PortonePaymentResponse result = portOneClient.getPayment(paymentId);
-            if (result == null) {
-                throw new ServiceException(ErrorCode.PORTONE_RESPONSE_NULL);
-            }
-
-            log.info("[PORTONE_PAYMENT] paymentId={}, status={}, amount={}",
-                    result.getPaymentId(), result.getStatus(), result.getAmount());
-
             // TODO 3) 결제/주문 상태 반영(Payment/Order 업데이트)
 
             // TODO 4) 처리 완료 마킹

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     import: optional:file:./secret.yml
 
 portone:
+  api:
+    base-url: https://api.portone.io
+    secret: ${PORTONE_API_SECRET:}
   webhook:
     secret: demo-webhook-secret-key
     secret-format: raw


### PR DESCRIPTION
## 📝 작업 내용
- paymentId 기반 PortOne 결제 조회 기능 구현
  - PortOne 결제 조회 API (`GET /payments/{paymentId}`) 연동
  - 외부 API 호출 로직 구현

- PortOneClient 인터페이스 및 구현체 작성
  - PortOneClient 인터페이스 정의
  - PortOneClientImpl에서 실제 PortOne API 호출 처리

- webhook 처리에서 PortOne 결제 조회 가능하도록 구조 구성
  - webhook payload의 paymentId를 기반으로 PortOne 결제 정보 조회 가능하도록 연동 준비

- 외부 API 호출 실패 시 예외 처리 로직 추가
  - ServiceException으로 변환하여 일관된 예외 처리 구조 적용

## 🔗 관련 이슈 (Related Issues)
Closes #22 

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항