### PR TITLE
feat: webhook 환불 processed 적용

### DIFF
--- a/src/main/java/com/bootcamp/paymentproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
 
     // Refund
     PAYMENT_NOT_REFUNDABLE("PAYMENT_NOT_REFUNDABLE", "환불 가능한 결제 상태가 아닙니다.", HttpStatus.CONFLICT),
-    REFUND_NOT_FOUND("REFUND_NOT_FOUND", "존재하지 않는 환불 정보입니다.", HttpStatus.NOT_FOUND);
+    REFUND_NOT_FOUND("REFUND_NOT_FOUND", "존재하지 않는 환불 정보입니다.", HttpStatus.NOT_FOUND),
     PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND", "존재하지 않는 상품입니다.", HttpStatus.NOT_FOUND),
 
     INVALID_PAYMENT_STATUS_TRANSITION("INVALID_PAYMENT_STATUS_TRANSITION", "유효하지 않은 결제 상태 전이입니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/bootcamp/paymentproject/order/entity/Order.java
+++ b/src/main/java/com/bootcamp/paymentproject/order/entity/Order.java
@@ -56,8 +56,6 @@ public class Order extends BaseEntity {
     }
 
     public void orderCompleted() {this.status = OrderStatus.COMPLETED;}
-    public void orderCompleted() { this.status = OrderStatus.COMPLETED; }
-    public void orderRefunded() { this.status = OrderStatus.REFUNDED; }
 
     public void orderPendingRefund(){
         this.status = OrderStatus.REFUND_PENDING;

--- a/src/main/java/com/bootcamp/paymentproject/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/bootcamp/paymentproject/payment/enums/PaymentStatus.java
@@ -17,11 +17,11 @@ public enum PaymentStatus {
         }
 
         return switch (this){
-            case PENDING -> targetStatus == APPROVED || targetStatus == FAILED || targetStatus == CANCELED;
-            case APPROVED, REFUND_FAILED -> targetStatus == CANCELED;
-            case CANCELED -> targetStatus == REFUNDED || targetStatus == REFUND_FAILED;
+            case PENDING -> targetStatus == APPROVED || targetStatus == FAILED || targetStatus == CANCELED || targetStatus == REFUNDED;
+            case APPROVED -> targetStatus == REFUNDED || targetStatus == CANCELED;
+            case REFUND_FAILED -> targetStatus == CANCELED || targetStatus == REFUNDED;
+            case CANCELED -> targetStatus == REFUNDED || targetStatus == REFUND_FAILED || targetStatus == CANCELED;
             case FAILED, REFUNDED -> false;
         };
-
     }
 }

--- a/src/main/java/com/bootcamp/paymentproject/webhook/service/WebhookService.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/service/WebhookService.java
@@ -2,30 +2,12 @@ package com.bootcamp.paymentproject.webhook.service;
 
 import com.bootcamp.paymentproject.common.exception.ErrorCode;
 import com.bootcamp.paymentproject.common.exception.ServiceException;
-import com.bootcamp.paymentproject.order.entity.Order;
-import com.bootcamp.paymentproject.order.entity.OrderProduct;
-import com.bootcamp.paymentproject.payment.entity.Payment;
-import com.bootcamp.paymentproject.payment.enums.PaymentStatus;
-import com.bootcamp.paymentproject.payment.repository.PaymentRepository;
 import com.bootcamp.paymentproject.portone.PortOnePaymentResponse;
 import com.bootcamp.paymentproject.portone.client.PortOneClient;
-import com.bootcamp.paymentproject.product.entity.Product;
-import com.bootcamp.paymentproject.product.repository.ProductRepository;
 import com.bootcamp.paymentproject.webhook.dto.PortoneWebhookPayload;
-import com.bootcamp.paymentproject.webhook.entity.WebhookEvent;
-import com.bootcamp.paymentproject.webhook.repository.WebhookEventRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,29 +18,31 @@ public class WebhookService {
     private final WebhookTxService webhookTxService;
 
     /**
-     * PortOne webhook 처리 흐름
-     //* 1) webhookId 멱등 처리(중복이면 무시)
-     * 2) webhook_event 저장(RECEIVED)
-     //* 3) PortOne 결제 조회(SSOT)
-     //* 4) 결제/주문 상태 DB 반영
-     //* 5) webhook_event 처리 결과 기록(PROCESSED/FAILED)
+     * PortOne webhook 처리
+     *
+     * 흐름:
+     * 1) webhook payload에서 paymentId 추출
+     * 2) PortOne API로 실제 결제 정보 조회
+     * 3) 조회 결과를 기반으로 DB 상태 변경 (트랜잭션 처리)
      */
-    public void handleVerifiedWebhook(String webhookId,                    // 중복인지 확인
-                                      String webhookTimestamp,             // 유효한 요청인지 확인
-                                      PortoneWebhookPayload payload) {     // 실제 결제 처리
+    public void handleVerifiedWebhook(String webhookId,
+                                      String webhookTimestamp,
+                                      PortoneWebhookPayload payload) {
 
-        // TODO 2) PortOne 결제 조회(SSOT)
+        // paymentId 추출
         String paymentId = payload.getData().getPaymentId();
 
+        // PortOne API로 결제 상태 조회
         PortOnePaymentResponse result = portOneClient.getPayment(paymentId);
         if (result == null) {
             throw new ServiceException(ErrorCode.PORTONE_RESPONSE_NULL);
         }
 
+        // 조회 결과 로그
         log.info("[PORTONE_PAYMENT] paymentId={}, status={}, amount={}",
                 result.getPaymentId(), result.getStatus(), result.getAmount());
 
-        // 외부 API 조회가 끝난 다음에, DB 반영 로직만 트랜잭션으로 처리
+        // DB 상태 반영 (결제 상태 변경, webhook_event 기록)
         webhookTxService.handleAfterFetch(webhookId, webhookTimestamp, payload, result);
     }
 }

--- a/src/main/java/com/bootcamp/paymentproject/webhook/service/WebhookTxService.java
+++ b/src/main/java/com/bootcamp/paymentproject/webhook/service/WebhookTxService.java
@@ -36,12 +36,14 @@ public class WebhookTxService {
     private final ProductRepository productRepository;
 
     /**
-     * PortOne webhook 처리 흐름
-     * 1) webhookId 멱등 처리(중복이면 무시)
-     //* 2) webhook_event 저장(RECEIVED)
-     * 3) PortOne 결제 조회(SSOT)
-     * 4) 결제/주문 상태 DB 반영
-     * 5) webhook_event 처리 결과 기록(PROCESSED/FAILED)
+     * PortOne webhook DB 반영 처리 (트랜잭션)
+     *
+     * 흐름:
+     * 1) webhook_event 저장 (멱등 처리)
+     * 2) Payment / Order 조회
+     * 3) 결제 상태 검증 및 상태 변경
+     * 4) 재고 차감 (결제 승인 시)
+     * 5) webhook_event 상태를 PROCESSED 또는 FAILED로 기록
      */
     @Transactional
     public void handleAfterFetch(String webhookId,
@@ -49,11 +51,13 @@ public class WebhookTxService {
                                  PortoneWebhookPayload payload,
                                  PortOnePaymentResponse result) {
 
+        // 1. 중복 webhook 검사 (멱등 처리)
         if (webhookEventRepository.findByWebhookId(webhookId).isPresent()) {
             log.info("[PORTONE_WEBHOOK] duplicate webhookId={}, ignore", webhookId);
             return;
         }
 
+        // webhook_event 저장 (RECEIVED 상태)
         WebhookEvent event;
         try {
             event = WebhookEvent.received(
@@ -69,6 +73,7 @@ public class WebhookTxService {
         }
 
         try {
+            // 2. Payment / Order 조회
             String paymentId = result.getPaymentId();
 
             Payment payment = paymentRepository.findByPaymentId(paymentId)
@@ -76,81 +81,143 @@ public class WebhookTxService {
 
             Order order = payment.getOrder();
 
-            BigDecimal portoneAmount = result.amount() != null ? result.amount().total() : null;
-            BigDecimal orderAmount = order.getTotalPrice();
+            // 3. 결제 금액 검증 (취소/환불은 제외)
+            String rawStatus = result.getStatus();
+            boolean isRefunded = "REFUNDED".equalsIgnoreCase(rawStatus);
+            boolean isCanceledLike = rawStatus != null &&
+                    ("CANCELED".equalsIgnoreCase(rawStatus) ||
+                            "CANCELLED".equalsIgnoreCase(rawStatus) ||
+                            isRefunded);
 
-            if (portoneAmount == null || orderAmount == null || portoneAmount.compareTo(orderAmount) != 0) {
-                log.error("[PORTONE_WEBHOOK] amount mismatch paymentId={}, portoneAmount={}, orderAmount={}",
-                        paymentId, portoneAmount, orderAmount);
-                throw new ServiceException(ErrorCode.PORTONE_API_ERROR);
+            // 취소/환불은 amount 검증 스킵
+            if (!isCanceledLike) {
+                BigDecimal portoneAmount = result.amount() != null ? result.amount().total() : null;
+                BigDecimal orderAmount = order.getTotalPrice();
+
+                if (portoneAmount == null || orderAmount == null || portoneAmount.compareTo(orderAmount) != 0) {
+
+                    log.error("[PORTONE_WEBHOOK] amount mismatch paymentId={}, portoneAmount={}, orderAmount={}", paymentId, portoneAmount, orderAmount);
+                    throw new ServiceException(ErrorCode.PORTONE_API_ERROR);
+                }
             }
 
+            // 상태 변환
             PaymentStatus targetStatus = maptoPaymentStatus(result.getStatus());
+            PaymentStatus currentStatus = payment.getStatus();
 
+            // 이미 환불 완료 상태면 늦게 온 이벤트 무시 (멱등)
+            if (currentStatus == PaymentStatus.REFUNDED && targetStatus != PaymentStatus.REFUNDED) {
+
+                log.info("[PORTONE_WEBHOOK] ignore late/out-of-order event. paymentId={}, current={}, target={}, rawStatus={}", paymentId, currentStatus, targetStatus, result.getStatus());
+                event.markProcessed();
+                webhookEventRepository.save(event);
+                return;
+            }
+
+            // 상태 전이 검증
             if (!payment.getStatus().canTransitToTargetStatus(targetStatus)) {
-                log.warn("[PORTONE_WEBHOOK] invalid transition paymentId={}, {} -> {}",
-                        paymentId, payment.getStatus(), targetStatus);
                 throw new ServiceException(ErrorCode.INVALID_PAYMENT_STATUS_TRANSITION);
             }
 
+            // 4. 결제 상태 변경
             switch (targetStatus) {
+
+                // 결제 승인 → 재고 차감, 주문 완료
                 case APPROVED -> {
                     decreaseStockForOrder(order);
                     payment.paymentConfirmed();
                     order.orderCompleted();
-                    log.info("[PORTONE_WEBHOOK] payment approved paymentId={}", paymentId);
                 }
+
+                // 결제 실패
                 case FAILED -> payment.paymentFailed();
+
+                // 결제 취소
                 case CANCELED -> {
                     payment.paymentCanceled();
                     order.orderRefunded();
                 }
-                case PENDING -> log.info("[PORTONE_WEBHOOK] payment pending paymentId={}", paymentId);
+
+                // 환불 완료
+                case REFUNDED -> {
+                    payment.paymentRefunded();
+                    order.orderRefunded();
+                }
+
+                // 환불 실패
+                case REFUND_FAILED -> payment.paymentRefundFailed();
+
+                // 결제 대기 상태
+                case PENDING -> { }
             }
 
+            // 처리 완료 기록
             event.markProcessed();
 
         } catch (ServiceException ex) {
-            log.error("[PORTONE_WEBHOOK] processing failed webhookId={}, code={}",
-                    webhookId, ex.getErrorCode().getCode(), ex);
+
+            // 처리 실패 기록
+            log.error("[PORTONE_WEBHOOK] processing failed webhookId={}, code={}", webhookId, ex.getErrorCode().getCode(), ex);
             event.markFailed();
+
         } catch (Exception ex) {
+
             log.error("[PORTONE_WEBHOOK] unexpected error webhookId={}", webhookId, ex);
             event.markFailed();
         }
     }
 
     /**
-     * PortOne status(String) -> 우리 PaymentStatus(Enum) 변환
+     * PortOne 결제 상태(String)를 우리 시스템의 PaymentStatus(Enum)로 변환
      */
     private PaymentStatus maptoPaymentStatus(String status) {
 
+        // status가 없는 경우 예외 처리
         if (status == null) { throw new ServiceException(ErrorCode.PORTONE_RESPONSE_NULL); }
 
+        // PortOne 상태 값을 우리 시스템 상태로 변환
         return switch (status.toUpperCase()) {
+            // 결제 완료
             case "PAID", "APPROVED", "COMPLETED" -> PaymentStatus.APPROVED;
+            // 결제 실패
             case "FAILED" -> PaymentStatus.FAILED;
-            case "CANCELED", "CANCELLED", "REFUNDED" -> PaymentStatus.CANCELED;
+            // 결제 취소
+            case "CANCELED", "CANCELLED" -> PaymentStatus.CANCELED;
+            // 환불 완료
+            case "REFUNDED" -> PaymentStatus.REFUNDED;
+            // 결제 대기 상태
             case "PENDING", "READY" -> PaymentStatus.PENDING;
+            // 알 수 없는 상태 예외 처리
             default -> throw new ServiceException(ErrorCode.PORTONE_API_ERROR);
         };
     }
 
     /**
-     * 재고 차감 (Order.orderProducts 기준)
-     * - ProductRepository.findAllByIdIn()에 PESSIMISTIC_WRITE가 걸려있어서 동시성 방어됨
-     * - Product.decreaseStock(qty) 내부에서 "재고 부족"이면 예외 던지도록 하는 게 안전함(롤백)
+     * 주문에 포함된 상품들의 재고를 차감
+     *
+     * 흐름:
+     * 1) 주문 상품 목록 조회
+     * 2) 상품 ID별로 차감할 수량 계산
+     * 3) 상품을 비관적 락으로 조회 (동시성 방어)
+     * 4) 각 상품의 재고 감소
      */
     private void decreaseStockForOrder(Order order) {
+
+        // 주문 상품 목록 조회
         List<OrderProduct> orderProducts = order.getOrderProducts();
+
         if (orderProducts == null || orderProducts.isEmpty()) return;
 
+        // 상품별 차감 수량 계산
         Map<Long, Long> qtyByProductId = new HashMap<>();
+
         for (OrderProduct op : orderProducts) {
+
             if (op.getProduct() == null || op.getProduct().getId() == null) continue;
 
             Long productId = op.getProduct().getId();
             Long qty = op.getStock();
+
             if (qty == null || qty <= 0) continue;
 
             qtyByProductId.merge(productId, qty, Long::sum);
@@ -160,15 +227,15 @@ public class WebhookTxService {
 
         List<Long> productIds = new ArrayList<>(qtyByProductId.keySet());
 
-        // 비관락으로 상품 행 잠금
+        // 상품을 비관적 락으로 조회(동시에 여러 결제가 재고를 수정하는 상황 방지)
         List<Product> products = productRepository.findAllByIdIn(productIds);
 
-        // 조회 누락 방어
+        // 조회된 상품 수가 다르면 예외 처리
         if (products.size() != productIds.size()) {
-            // ErrorCode.PRODUCT_NOT_FOUND 없으면 PORTONE_API_ERROR로 임시 대체 가능
             throw new ServiceException(ErrorCode.PRODUCT_NOT_FOUND);
         }
 
+        // 상품 ID → Product 매핑
         Map<Long, Product> productMap = products.stream()
                 .collect(Collectors.toMap(Product::getId, p -> p));
 
@@ -180,7 +247,8 @@ public class WebhookTxService {
             Product product = productMap.get(productId);
             if (product == null) throw new ServiceException(ErrorCode.PRODUCT_NOT_FOUND);
 
-            product.decreaseStock(qty); // Product 안에 이미 있음
+            // 실제 재고 감소
+            product.decreaseStock(qty);
         }
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- PortOne webhook에서 환불 상태(REFUNDED) 처리 로직 추가
- PortOne 결제 조회 결과 status가 REFUNDED인 경우 Payment 상태를 REFUNDED로 변경하도록 구현
- Payment 엔티티에 paymentRefunded() 상태 전이 메서드 활용하여 안전한 상태 변경 처리
- webhook_event 처리 결과를 PROCESSED로 기록하도록 로직 추가
- webhook 처리 흐름에서 결제 상태에 따라 PAID / FAILED / REFUNDED 상태 반영 분기 처리 구현
- PortOneClient를 통해 SSOT 기반으로 결제 상태 조회 후 DB 상태 반영하도록 구성

## 🔗 관련 이슈 (Related Issues)
Closes #31 

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항