### PR TITLE
feat : 포인트-주문_적립,사용,멤버십계산율

### DIFF
--- a/src/main/java/com/bootcamp/paymentproject/order/Controller/OrderController.java
+++ b/src/main/java/com/bootcamp/paymentproject/order/Controller/OrderController.java
@@ -8,6 +8,7 @@ import com.bootcamp.paymentproject.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,11 +23,12 @@ public class OrderController {
     // 주문 생성
     @PostMapping
     public ResponseEntity<SuccessResponse<OrderCreateResponse>> createOrder(
-            @RequestBody OrderCreateRequest request
+            @RequestBody OrderCreateRequest request,
+            Authentication authentication
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.success(
-                        orderService.createOrder(request),
+                        orderService.createOrder(request, authentication),
                         "주문 생성 완료"
                 ));
     }

--- a/src/main/java/com/bootcamp/paymentproject/order/entity/Order.java
+++ b/src/main/java/com/bootcamp/paymentproject/order/entity/Order.java
@@ -44,6 +44,7 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    public void setUser(User user) { this.user = user; }
 
     // 생성자 오류 해결
     public static Order create() {


### PR DESCRIPTION
## 📝 작업 내용
- 주문 정보 조회시,  맨 처음 주문 생성 후 조회단계에서는 사용포인트 값은 0
- 적립 포인트 값은 주문과 연결된 유저를 통해 멤버십 적립률가지고 계산
- 이후 포인트로 결제를 눌러서 결제 생성이 성공하여 주문 테이블의 사용 포인트 필드값이 변경되면, 그 다음부터 주문 정보를 조회할떄 사용포인트 값이 표시 
- 적립 포인트는 0으로(포인트 사용시 적립x)


## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [ ] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항