### PR TITLE
fix : 매서드 표기 오류 수정(두 필드명이 독립인데, 붙여씀)

### DIFF
--- a/src/main/java/com/bootcamp/paymentproject/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/bootcamp/paymentproject/point/repository/PointTransactionRepository.java
@@ -18,5 +18,5 @@ public interface PointTransactionRepository extends JpaRepository<PointTransacti
     // ExpireAt -> ExpiredAt (엔티티 필드명과 일치)
     List<PointTransaction> findAllByTypeAndExpiredAtBefore(PointType type, LocalDateTime dateTime);
 
-    List<PointTransaction> findAllByTypeSwitchToTypeEarnAtBefore(PointType pointType, LocalDateTime now);
+    List<PointTransaction> findAllByTypeAndSwitchToTypeEarnAtBefore(PointType pointType, LocalDateTime now);
 }

--- a/src/main/java/com/bootcamp/paymentproject/point/service/PointService.java
+++ b/src/main/java/com/bootcamp/paymentproject/point/service/PointService.java
@@ -22,7 +22,7 @@ public class PointService {
     public void processPendingPoints() {
         // 엔티티에 earnAt이 없으므로 createdAt 기준으로 처리
         List<PointTransaction> holdings = pointTransactionRepository
-                .findAllByTypeSwitchToTypeEarnAtBefore(PointType.HOLDING, LocalDateTime.now());
+                .findAllByTypeAndSwitchToTypeEarnAtBefore(PointType.HOLDING, LocalDateTime.now());
 
         for (PointTransaction tx : holdings) {
             tx.updateType(PointType.EARN);


### PR DESCRIPTION
## 📝 작업 내용
- 매서드 표기 오류 수정(두 필드명이 독립인데, 붙여씀)


## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
- [ ] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [ ] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항