### PR TITLE
refactor: 포인트 예외 처리 구조 통합

### DIFF
--- a/src/main/java/com/bootcamp/paymentproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/exception/ErrorCode.java
@@ -35,7 +35,10 @@ public enum ErrorCode {
     // User
     DUPLICATE_EMAIL("DUPLICATE_EMAIL", "중복된 이메일입니다", HttpStatus.CONFLICT),
     NOT_FOUND_USER("NOT_FOUND_USER", "존재하지 않는 유저입니다", HttpStatus.NOT_FOUND),
-    NOT_FOUND_GRADE("NOT_FOUND_GRADE", "존재하지 않는 등급입니다", HttpStatus.NOT_FOUND);
+    NOT_FOUND_GRADE("NOT_FOUND_GRADE", "존재하지 않는 등급입니다", HttpStatus.NOT_FOUND),
+
+    // POINT
+    INVALID_POINT_AMOUNT("INVALID_POINT_AMOUNT", "포인트 금액이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/bootcamp/paymentproject/common/exception/ServiceException.java
+++ b/src/main/java/com/bootcamp/paymentproject/common/exception/ServiceException.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class ServiceException extends RuntimeException {
     private final ErrorCode errorCode;
+
     public ServiceException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;

--- a/src/main/java/com/bootcamp/paymentproject/point/entity/PointTransaction.java
+++ b/src/main/java/com/bootcamp/paymentproject/point/entity/PointTransaction.java
@@ -1,6 +1,8 @@
 package com.bootcamp.paymentproject.point.entity;
 
 import com.bootcamp.paymentproject.common.entity.BaseEntity;
+import com.bootcamp.paymentproject.common.exception.ErrorCode;
+import com.bootcamp.paymentproject.common.exception.ServiceException;
 import com.bootcamp.paymentproject.order.entity.Order;
 import com.bootcamp.paymentproject.point.enums.PointType;
 import com.bootcamp.paymentproject.user.entity.User;
@@ -39,7 +41,7 @@ public class PointTransaction extends BaseEntity {
     private LocalDateTime switchToTypeEarnAt;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -90,7 +92,7 @@ public class PointTransaction extends BaseEntity {
     // 포인트 취소/상쇄 트랜잭션 생성 (CANCEL, 부호 그대로 사용)
     public static PointTransaction cancel(User user, Order order, BigDecimal amount) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) == 0) {
-            throw new IllegalArgumentException("cancel amount must be non-zero");
+            throw new ServiceException(ErrorCode.INVALID_POINT_AMOUNT);
         }
         return of(user, order, PointType.CANCEL, amount, BigDecimal.ZERO, null);
     }
@@ -98,7 +100,7 @@ public class PointTransaction extends BaseEntity {
     // 사용 포인트 복구 (+금액으로 CANCEL 생성)
     public static PointTransaction cancelSpendRestore(User user, Order order, BigDecimal restoreAmount) {
         if (restoreAmount == null || restoreAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("restoreAmount must be positive");
+            throw new ServiceException(ErrorCode.INVALID_POINT_AMOUNT);
         }
         return cancel(user, order, restoreAmount.abs());
     }
@@ -106,7 +108,7 @@ public class PointTransaction extends BaseEntity {
     // HOLDING 포인트 무효화 (-금액으로 CANCEL 생성)
     public static PointTransaction cancelHolding(User user, Order order, BigDecimal holdingAmount) {
         if (holdingAmount == null || holdingAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("holdingAmount must be positive");
+            throw new ServiceException(ErrorCode.INVALID_POINT_AMOUNT);
         }
         return cancel(user, order, holdingAmount.abs().negate());
     }


### PR DESCRIPTION
## 📝 작업 내용
- 포인트 관련 예외를 ServiceException + ErrorCode 기반으로 통합
- 기존에 분산되어 있던 개별 예외 클래스를 공통 구조로 정리
- 포인트 도메인에서 발생하는 예외를 일관된 응답 형태로 반환하도록 리팩토링
- 예외 메시지 및 HTTP 상태 코드 매핑 정리

## 🔗 관련 이슈 (Related Issues)
Closes #53

## ✅ 체크리스트 (Checklist)
- [x] 브랜치 이름 규칙을 준수했나요? (예: feat/login)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항